### PR TITLE
Fix leftover Firestorm branding

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3111,7 +3111,7 @@ bool LLAppViewer::initConfiguration()
         // <FS>
         if (gSavedSettings.getString("SessionSettingsFile").empty())
         {
-            gSavedSettings.setString("SessionSettingsFile", "settings_firestorm.xml");
+            gSavedSettings.setString("SessionSettingsFile", "settings_finalviewer.xml");
         }
         // </FS>
 

--- a/indra/newview/skins/default/xui/en/panel_fs_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_login.xml
@@ -330,9 +330,9 @@
           name="mode_combo"
           width="110">
            <combo_box.item
-            label="Firestorm"
-            name="Firestorm"
-            value="settings_firestorm.xml" />
+            label="Finalviewer"
+            name="Finalviewer"
+            value="settings_finalviewer.xml" />
            <combo_box.item
             label="Phoenix"
             name="Phoenix"

--- a/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
@@ -351,9 +351,9 @@
       <combo_box.drop_down_button
         font="SansSerifLarge"/>
       <combo_box.item
-        label="Firestorm"
-        name="Firestorm"
-        value="settings_firestorm.xml" />
+        label="Finalviewer"
+        name="Finalviewer"
+        value="settings_finalviewer.xml" />
       <combo_box.item
         label="Phoenix"
         name="Phoenix"

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -7,15 +7,15 @@
 
 	<!-- Default Args - these arguments will be replaced in all strings -->
 	<string name="SECOND_LIFE">[CURRENT_GRID]</string>
-	<string name="APP_NAME">Firestorm</string>
-	<string name="CAPITALIZED_APP_NAME">FIRESTORM</string>
+        <string name="APP_NAME">Finalviewer</string>
+        <string name="CAPITALIZED_APP_NAME">FINALVIEWER</string>
 	<string name="SECOND_LIFE_GRID">Second Life Grid</string>
-	<string name="SUPPORT_SITE">Firestorm Support Portal</string>
-	<string name="DOWNLOAD_URL">https://www.firestormviewer.org/choose-your-platform/</string>
+        <string name="SUPPORT_SITE">Finalviewer Support Portal</string>
+        <string name="DOWNLOAD_URL">https://www.finalviewerviewer.org/choose-your-platform/</string>
 	<string name="CURRENT_GRID"/> <!-- Will be set in fsgridhandler.cpp / llviewernetwork.cpp -->
 	<string name="VIEWER_GENERATION">Viewer [VERSION]</string>
 	<string name="SHORT_VIEWER_GENERATION">V[VERSION]</string>
-	<string name="APP_NAME_ABBR">FS</string>
+        <string name="APP_NAME_ABBR">FV</string>
 
 	<!-- starting up -->
 	<string name="StartupDetectingHardware">Detecting hardware...</string>


### PR DESCRIPTION
## Summary
- update app name strings to Finalviewer
- fix login mode labels
- default to `settings_finalviewer.xml`
- revert nib change per feedback

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError)*


------
https://chatgpt.com/codex/tasks/task_e_6857c4426d848332a1302b0cbf453676