### PR TITLE
Add iOS SwiftUI app scaffold

### DIFF
--- a/doc/ios_app.md
+++ b/doc/ios_app.md
@@ -1,0 +1,23 @@
+# Finalviewer iOS App
+
+This folder contains a minimal Swift package that can be opened in Xcode to run the viewer core on iOS.
+
+## Prerequisites
+
+- Xcode 15 or newer
+- iOS 15 SDK
+- The viewer dynamic library built following [building_ios.md](building_ios.md)
+
+## Opening the project
+
+1. Build the dynamic library using the instructions in `doc/building_ios.md`.
+2. Open `ios/Package.swift` in Xcode. The package defines an executable target `FinalviewerApp`.
+3. Ensure the built viewer dynamic library is accessible to the project (for example by copying the resulting `.dylib` into a location referenced by the "viewer" linker setting).
+4. Select the `FinalviewerApp` scheme and run on a simulator or device.
+
+## Integrating assets
+
+- Copy any required textures, meshes and UI assets into `ios/Sources/FinalviewerApp` or add them via the Xcode asset catalog.
+- Modify `Package.swift` if additional resource bundles are needed.
+
+The SwiftUI interface provides login, chat and HUD layers while `WorldView` uses SceneKit with gesture recognizers for camera control. The `ViewerBridge` layer exposes functions from the C++ core.

--- a/ios/Bridging/ViewerBridge.h
+++ b/ios/Bridging/ViewerBridge.h
@@ -1,0 +1,44 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+#import <Foundation/Foundation.h>
+#import "../../indra/newview/llappviewerosx-ios-objc.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ViewerBridge : NSObject
++ (void)constructViewer;
++ (BOOL)initViewer;
++ (BOOL)pumpFrame;
++ (void)handleURL:(NSString *)url;
++ (void)quit;
++ (void)cleanupViewer;
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/ios/Bridging/ViewerBridge.mm
+++ b/ios/Bridging/ViewerBridge.mm
@@ -1,0 +1,58 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+#import "ViewerBridge.h"
+
+@implementation ViewerBridge
+
++ (void)constructViewer {
+    ios_construct_viewer();
+}
+
++ (BOOL)initViewer {
+    return ios_init_viewer();
+}
+
++ (BOOL)pumpFrame {
+    return ios_pump_frame();
+}
+
++ (void)handleURL:(NSString *)url {
+    ios_handle_url([url UTF8String]);
+}
+
++ (void)quit {
+    ios_quit();
+}
+
++ (void)cleanupViewer {
+    ios_cleanup_viewer();
+}
+
+@end
+

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "FinalviewerIOS",
+    platforms: [.iOS(.v15)],
+    products: [
+        .executable(name: "FinalviewerApp", targets: ["FinalviewerApp"])
+    ],
+    targets: [
+        .target(
+            name: "ViewerBridge",
+            path: "Bridging",
+            publicHeadersPath: ".",
+            cSettings: [
+                .headerSearchPath("../../indra/newview")
+            ],
+            linkerSettings: [
+                .linkedLibrary("viewer")
+            ]
+        ),
+        .executableTarget(
+            name: "FinalviewerApp",
+            dependencies: ["ViewerBridge"],
+            path: "Sources/FinalviewerApp"
+        )
+    ]
+)

--- a/ios/Sources/FinalviewerApp/ChatView.swift
+++ b/ios/Sources/FinalviewerApp/ChatView.swift
@@ -1,0 +1,46 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import SwiftUI
+
+struct ChatView: View {
+    @State private var message: String = ""
+    var body: some View {
+        HStack {
+            TextField("Chat...", text: $message)
+                .textFieldStyle(.roundedBorder)
+            Button("Send") {
+                ViewerCore.handle(url: "chat://\(message)")
+                message = ""
+            }
+        }
+        .padding()
+        .background(.regularMaterial)
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/ContentView.swift
+++ b/ios/Sources/FinalviewerApp/ContentView.swift
@@ -1,0 +1,54 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var session: ViewerSession
+
+    var body: some View {
+        ZStack {
+            WorldView()
+            HUDView()
+            if !session.loggedIn {
+                LoginView()
+            }
+        }
+        .onAppear {
+            ViewerCore.construct()
+            _ = ViewerCore.initialize()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView().environmentObject(ViewerSession())
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/FinalviewerApp.swift
+++ b/ios/Sources/FinalviewerApp/FinalviewerApp.swift
@@ -1,0 +1,42 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import SwiftUI
+
+@main
+struct FinalviewerApp: App {
+    @StateObject private var session = ViewerSession()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(session)
+        }
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/HUDView.swift
+++ b/ios/Sources/FinalviewerApp/HUDView.swift
@@ -1,0 +1,39 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import SwiftUI
+
+struct HUDView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            ChatView()
+        }
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/LoginView.swift
+++ b/ios/Sources/FinalviewerApp/LoginView.swift
@@ -1,0 +1,53 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import SwiftUI
+
+struct LoginView: View {
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @EnvironmentObject var session: ViewerSession
+
+    var body: some View {
+        VStack {
+            TextField("Username", text: $username)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            Button("Login") {
+                session.login(username: username, password: password)
+            }
+            .padding(.top, 8)
+        }
+        .padding()
+        .background(.regularMaterial)
+        .cornerRadius(12)
+        .padding()
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/ViewerBridge.swift
+++ b/ios/Sources/FinalviewerApp/ViewerBridge.swift
@@ -1,0 +1,56 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import Foundation
+
+public enum ViewerCore {
+    public static func construct() {
+        ViewerBridge.constructViewer()
+    }
+
+    public static func initialize() -> Bool {
+        ViewerBridge.initViewer()
+    }
+
+    public static func pumpFrame() -> Bool {
+        ViewerBridge.pumpFrame()
+    }
+
+    public static func handle(url: String) {
+        ViewerBridge.handleURL(url)
+    }
+
+    public static func quit() {
+        ViewerBridge.quit()
+    }
+
+    public static func cleanup() {
+        ViewerBridge.cleanupViewer()
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/ViewerSession.swift
+++ b/ios/Sources/FinalviewerApp/ViewerSession.swift
@@ -1,0 +1,40 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import Foundation
+
+final class ViewerSession: ObservableObject {
+    @Published var loggedIn: Bool = false
+
+    func login(username: String, password: String) {
+        // TODO: pass credentials to the viewer core
+        ViewerCore.handle(url: "login://\(username)")
+        loggedIn = true
+    }
+}
+

--- a/ios/Sources/FinalviewerApp/WorldView.swift
+++ b/ios/Sources/FinalviewerApp/WorldView.swift
@@ -1,0 +1,56 @@
+/** 
+ * @file 
+ * @brief 
+ *
+ * $LicenseInfo:firstyear=2025&license=fsviewerlgpl$
+ * Finalviewer Viewer Source Code
+ * Copyright (C) 2025, The Finalviewer Project, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * The Finalviewer Project, Inc., 1831 Oakwood Drive, Fairmont, Minnesota 56031-3225 USA
+ * http://www.finalviewer.org
+ * $/LicenseInfo$
+ */
+
+
+import SwiftUI
+import SceneKit
+
+struct WorldView: UIViewRepresentable {
+    func makeUIView(context: Context) -> SCNView {
+        let view = SCNView()
+        view.scene = SCNScene()
+        view.allowsCameraControl = true
+        let pan = UIPanGestureRecognizer(target: context.coordinator,
+                                         action: #selector(Coordinator.pan(_:)))
+        view.addGestureRecognizer(pan)
+        return view
+    }
+
+    func updateUIView(_ uiView: SCNView, context: Context) {
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    class Coordinator: NSObject {
+        @objc func pan(_ gesture: UIPanGestureRecognizer) {
+            // TODO: send gesture data to the viewer core
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Swift package scaffold under `ios/`
- implement bridging layer to call existing viewer C++ hooks
- add SwiftUI screens: login, chat, HUD, and SceneKit world
- document how to run the iOS app

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9ed26f288332836d1ec9fa12897c