### PR TITLE
Update iOS docs and fix build variable check

### DIFF
--- a/doc/building_ios.md
+++ b/doc/building_ios.md
@@ -10,6 +10,17 @@ These steps describe how to build the viewer core as a dynamic library for iOS.
 1. Download and install Xcode from the Mac App Store or the [Apple developer website](https://developer.apple.com/download).
 2. Launch Xcode once so that it installs the required command line tools and iOS SDK.
 
+## Prepare the build environment
+
+1. The repository already contains the `fs-build-variables` directory at its root, so there is no
+   need to clone it separately.
+2. Export the variables file and configure Autobuild so the required compiler flags are defined:
+   ```bash
+   export AUTOBUILD_VARIABLES_FILE=../fs-build-variables/variables
+   autobuild configure -A 64 -c ReleaseFS_open
+   ```
+   Running `autobuild configure` populates the `LL_BUILD` environment variable used by the CMake scripts.
+
 ## Configure CMake
 
 1. Create a build directory:
@@ -17,9 +28,10 @@ These steps describe how to build the viewer core as a dynamic library for iOS.
    mkdir build-ios
    cd build-ios
    ```
-2. Run CMake with the provided toolchain file:
+2. Run CMake from the repository root using the iOS toolchain. Configuring from
+   the root ensures that CMake can locate the modules under `indra/cmake`:
    ```
-   cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-iOS.cmake ../indra/newview
+   cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-iOS.cmake ../indra
    ```
 
 ## Build the dynamic library

--- a/indra/cmake/Variables.cmake
+++ b/indra/cmake/Variables.cmake
@@ -91,7 +91,7 @@ else (ADDRESS_SIZE EQUAL 32)
             "import platform; print( platform.machine() )"
             OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
     string( REGEX MATCH ".*(64)$" RE_MATCH "${ARCH}" )
-    if( RE_MATCH AND ${CMAKE_MATCH_1} STREQUAL "64" )
+    if( RE_MATCH AND "${CMAKE_MATCH_1}" STREQUAL "64" )
       set(ADDRESS_SIZE 64)
       set(ARCH x86_64)
     else()


### PR DESCRIPTION
## Summary
- fix quoting for `${CMAKE_MATCH_1}` in `Variables.cmake`
- update iOS build docs to use included `fs-build-variables` directory

## Testing
- `pre-commit run --files indra/cmake/Variables.cmake doc/building_ios.md` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860391bb34083329c2b4aef81020d67